### PR TITLE
impr(setup.sh): random improvements

### DIFF
--- a/postgres/setup.sh
+++ b/postgres/setup.sh
@@ -1,60 +1,56 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 [ "$UID" -eq 0 ] || {
   echo "This script must be run as root."
   exit 1
 }
-function booask() {
-  while true; do
-    read -p "$1 [y/n]: " yn
-    case $yn in
-    [Yy]*)
-      echo 0
-      break
-      ;;
-    [Nn]*)
-      echo 1
-      break
-      ;;
-    *) echo "Please answer y or n." ;;
+if ! tty -s; then
+  echo "This script must be run in an interactive terminal."
+  exit 1
+fi
+
+booask()
+{
+  while :; do
+    read -rp "$1 [y/n]: " yn
+    case "$yn" in
+      [Yy]*)
+        return
+        ;;
+      [Nn]*)
+        return 1
+        ;;
+      *)
+        echo "Please answer y or n."
+        ;;
     esac
   done
 }
 
-install=$(booask "Do you wan't to install postgres?")
-
-if [ $install -eq 0 ]; then
-  sudo apt install postgresql postgresql-contrib
+if booask 'Do you want to install postgres?'; then
+  apt install postgresql postgresql-contrib
 fi
 
-create_user=$(booask "Do you wan't to create a postgres user?")
-
-
-if [ $create_user -eq 0 ]
-  then
-    read -p "Postgres new user username? [$SUDO_USER]: " pg_user_username
-    pg_user_username=${pg_user_username:-$SUDO_USER}
-    read -p "And password?: " -s pg_user_pwd
-  else
-    read -p "Postgres existing user username? [$SUDO_USER]: " pg_user_username
-    pg_user_username=${pg_user_username:-$SUDO_USER}
+if booask 'Do you want to create a postgres user?'; then
+  read -rp "Postgres new user username? [$SUDO_USER]: " pg_user_username
+  pg_user_username="${pg_user_username:-$SUDO_USER}"
+  read -rp "And password?: " -s pg_user_pwd
+else
+  read -rp "Postgres existing user username? [$SUDO_USER]: " pg_user_username
+  pg_user_username="${pg_user_username:-$SUDO_USER}"
 fi
 
-sudo -u postgres psql -c "CREATE USER $pg_user_username WITH PASSWORD '$pg_user_pwd';"
-sudo -u postgres psql -c "ALTER ROLE $pg_user_username SET client_encoding TO 'utf8';"
-sudo -u postgres psql -c "ALTER ROLE $pg_user_username SET default_transaction_isolation TO 'read committed';"
-sudo -u postgres psql -c "ALTER ROLE $pg_user_username SET timezone TO 'UTC';"
+postgres psql <<SQL
+CREATE USER '$pg_user_username' WITH PASSWORD '$pg_user_pwd';
+ALTER ROLE '$pg_user_username' SET client_encoding TO 'utf8';
+ALTER ROLE '$pg_user_username' SET default_transaction_isolation TO 'read committed';
+ALTER ROLE '$pg_user_username' SET timezone TO 'UTC';
+SQL
 
-
-create_db=$(booask "Do you wan't to create a database?")
-
-if [ $create_db -eq 0 ]; then
-  read -p "Postgres database name?: " pg_db_name
-  sudo -u postgres psql -c "CREATE DATABASE $pg_db_name;"
-  sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE $pg_db_name TO $pg_user_username;"
+if booask 'Do you want to create a database?'; then
+  read -rp 'Postgres database name: ' pg_db_name
+  postgres psql <<SQL
+CREATE DATABASE '$pg_db_name';
+GRANT ALL PRIVILEGES ON DATABASE '$pg_db_name' TO '$pg_user_username';
+SQL
 fi
-
-
-
-
-
-


### PR DESCRIPTION
- Do not use `sudo`, since scrip start by testing it is run by `root`.
- Check the script is run from an interactive terminal since it interactively prompts user.
- Simplify `booask` to use the return code rather than output to `stdout`, avoids spawning a sub-shell to test the result.
- Stream all `psql` commands at once from a HereDoc.